### PR TITLE
fix : post format check in get_content_format function

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -768,7 +768,7 @@ if ( ! function_exists( 'cpschool_get_search_results_style' ) ) {
 				$post_format = 'search';
 			}
 		}
-		if( !isset( $post_format )  ) {
+		if( empty( $post_format )  ) {
 			$post_format = get_post_type();
 		}
 


### PR DESCRIPTION
Previously `$post_format` was checked by `!isset()`. But `$post_format` is already set before check. So the check will be always false.

So I have changed `!isset()` to `empty()`.